### PR TITLE
Setting push

### DIFF
--- a/src/main/java/com/ohgiraffers/COZYbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/auth/controller/AuthController.java
@@ -33,6 +33,7 @@ public class AuthController {
     public ResponseEntity<?> login(@RequestBody LoginDTO loginDTO) {
         AuthTokenDTO authTokenDTO = authService.login(loginDTO);
         log.info("로그인 성공");
+        log.info("token ::" + authTokenDTO.accessToken());
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", authTokenDTO.refreshToken())
                 .httpOnly(true)
                 .secure(true)

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/inquiry/controller/InquiryController.java
@@ -53,7 +53,7 @@ public class InquiryController {
         String token = servletRequest.getHeader("Authorization").substring(7);
         String userId = jwtTokenProvider.decodeUserIdFromJwt(token);
         log.info("Update Inquiry OK");
-        return inquiryService.updateInquiry(id, dto, userId);
+        return inquiryService.updateInquiry(id, dto);
     }
 
 

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/inquiry/service/InquiryService.java
@@ -35,12 +35,9 @@ public class InquiryService {
     }
 
     @Transactional
-    public Inquiry updateInquiry(Long id, InquiryUpdateDTO dto, String writer){
+    public Inquiry updateInquiry(Long id, InquiryUpdateDTO dto){
         Inquiry inquiry = inquiryRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Inquiry not found"));
-        if (!inquiry.getWriter().equals(writer)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission to update this inquiry");
-        }
 
         inquiry.setTitle(dto.getTitle());
         inquiry.setContent(dto.getContent());

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/projects/dto/CreateProjectDTO.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/projects/dto/CreateProjectDTO.java
@@ -12,10 +12,12 @@ public class CreateProjectDTO {
     // 프로젝트 이름
     private String projectName;
     // 프로젝트 종류
-    private String interest;
+    private String devInterest;
     // 프로젝트 설명
     private String description;
-    //
+    // プロジェクトマスター
     private String leaderName;
+    // gitHubUrl
+    private String gitHubUrl;
 }
 

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/projects/dto/UpdateProjectDTO.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/projects/dto/UpdateProjectDTO.java
@@ -1,0 +1,19 @@
+package com.ohgiraffers.COZYbe.domain.projects.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateProjectDTO {
+    private String projectName;
+    private String devInterest;
+    private String description;
+    private String gitHubUrl;
+    private String leaderName;
+}
+

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/projects/entity/Project.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/projects/entity/Project.java
@@ -1,35 +1,49 @@
 package com.ohgiraffers.COZYbe.domain.projects.entity;
 
 import com.ohgiraffers.COZYbe.common.BaseTimeEntity;
+import com.ohgiraffers.COZYbe.domain.task.entity.Task;
 import com.ohgiraffers.COZYbe.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "tbl_project")
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class Project extends BaseTimeEntity {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "project_Id")
+    @Column(name = "projectId")
     private Long projectId;
 
-    @Column(name = "project_name", nullable = false, unique = true, length = 100)
+    @Column(name = "projectName", nullable = false, unique = true, length = 100)
     private String projectName;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ownerId", nullable = false)
     private User owner;
 
-    @Column(name = "interest", nullable = false, length = 50)
-    private String interest;
+    @Column(name = "devInterest", nullable = false, length = 50)
+    private String devInterest;
 
     @Column(name = "description", nullable = false, length = 500)
     private String description;
 
     @Column(name = "leader_name", nullable = false, length = 100)
     private String leaderName;
-}
 
+    @Column(name = "gitHubUrl", nullable = true, length = 800)
+    private String gitHubUrl;
+
+
+    @OneToMany(
+            mappedBy = "project",
+            cascade = CascadeType.REMOVE,
+            orphanRemoval = true
+    )
+    @Builder.Default
+    private List<Task> tasks = new ArrayList<>();
+}

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/projects/service/ProjectService.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/projects/service/ProjectService.java
@@ -1,14 +1,18 @@
 package com.ohgiraffers.COZYbe.domain.projects.service;
 
 import com.ohgiraffers.COZYbe.domain.projects.dto.CreateProjectDTO;
+import com.ohgiraffers.COZYbe.domain.projects.dto.UpdateProjectDTO;
 import com.ohgiraffers.COZYbe.domain.projects.entity.Project;
 import com.ohgiraffers.COZYbe.domain.projects.repository.ProjectRepository;
 import com.ohgiraffers.COZYbe.domain.user.entity.User;
 import com.ohgiraffers.COZYbe.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.UUID;
 
@@ -23,20 +27,25 @@ public class ProjectService {
         return projectRepository.findByProjectName(projectName).isEmpty();
     }
 
+    // ProjectService#createProject
     public Project createProject(CreateProjectDTO dto, String userId) {
-//        System.out.println("dto :: " + dto.toString());
         User user = findUserById(userId);
 
         Project project = Project.builder()
                 .projectName(dto.getProjectName())
-                .interest(dto.getInterest())
+                .devInterest(dto.getDevInterest())
                 .description(dto.getDescription())
                 .leaderName(dto.getLeaderName())
+                .gitHubUrl(dto.getGitHubUrl())
                 .owner(user)
                 .build();
 
+
         return projectRepository.save(project);
     }
+
+
+
 
     public Project getProjectByUserId(String userId) {
         User user = findUserById(userId);
@@ -47,12 +56,10 @@ public class ProjectService {
 
     public Project getProjectByNameForUser(String projectName, String userId) {
         Project project = projectRepository.findByProjectName(projectName)
-                .orElseThrow(() -> new RuntimeException("프로젝트를 찾을 수 없습니다."));
-
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."));
         if (!project.getOwner().getUserId().toString().equals(userId)) {
-            throw new RuntimeException("본인의 프로젝트만 조회할 수 있습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인의 프로젝트만 조회할 수 있습니다.");
         }
-
         return project;
     }
 
@@ -63,12 +70,46 @@ public class ProjectService {
 
     @Transactional
     public void deleteProject(Long projectId, String userId) {
-        Project project = projectRepository.findById(projectId).orElseThrow(()->new RuntimeException("Not found with id: " + projectId));
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("Not found with id: " + projectId));
 
         if (!project.getOwner().getUserId().toString().equals(userId)) {
-            throw new RuntimeException("삭제의 권한이 없습니다.");
+            throw new AccessDeniedException("You are not the owner of this project.");
         }
 
         projectRepository.delete(project);
     }
+
+
+
+    @Transactional
+    public Project updateProject(UpdateProjectDTO dto, Long projectId, String userId) {
+        Project p = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."));
+
+        if (!p.getOwner().getUserId().toString().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인의 프로젝트만 수정할 수 있습니다.");
+        }
+
+        p.setProjectName(dto.getProjectName());
+        p.setDevInterest(dto.getDevInterest());
+        p.setDescription(dto.getDescription());
+        p.setGitHubUrl(dto.getGitHubUrl());
+        if (dto.getLeaderName() != null) p.setLeaderName(dto.getLeaderName());
+
+        return projectRepository.save(p);
+    }
+
+
+    public Project getProjectDetailForUser(String projectName, String userId) {
+        Project project = projectRepository.findByProjectName(projectName)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."));
+        if (!project.getOwner().getUserId().toString().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인의 프로젝트만 조회할 수 있습니다.");
+        }
+        return project;
+    }
+
+
+
 }

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/task/entity/Task.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/task/entity/Task.java
@@ -17,7 +17,7 @@ public class Task extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "task_id")
+    @Column(name = "taskId")
     private Long taskId;
 
     @Column(name = "title", nullable = false)
@@ -26,7 +26,7 @@ public class Task extends BaseTimeEntity {
     @Column(name = "status", nullable = false)
     private String status;
 
-    @Column(name = "nick_name")
+    @Column(name = "nickName")
     private String nickName;
 
     // DB는 task_text
@@ -34,10 +34,11 @@ public class Task extends BaseTimeEntity {
     private String taskText;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "project_id", referencedColumnName = "project_Id")
+    @JoinColumn(name = "projectId", referencedColumnName = "projectId", nullable = false)
     private Project project;
 
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "userId", nullable = false)
     private User user;
 }

--- a/src/main/java/com/ohgiraffers/COZYbe/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/ohgiraffers/COZYbe/domain/task/repository/TaskRepository.java
@@ -2,6 +2,10 @@ package com.ohgiraffers.COZYbe.domain.task.repository;
 
 import com.ohgiraffers.COZYbe.domain.task.entity.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;


### PR DESCRIPTION
DTO 키 불일치 (gitUrl ↔ gitHubUrl)

증상: 업데이트 후 githubUrl이 계속 null, 경우에 따라 500. 이후 상세조회도 깨짐.

원인: 프론트는 gitUrl로 전송, 백엔드는 gitHubUrl만 역직렬화.

해결: 키 통일(프론트 gitHubUrl로 전송) + 백엔드 DTO에 @JsonProperty("gitUrl") 보조 세터 추가로 하위호환.

재발 방지: 컨트랙트 테스트(스냅샷/통합테스트)와 Bean Validation 도입.

엔티티 그대로 반환 → Jackson 직렬화 폭탄(LAZY/양방향)

증상: PUT /project/{id} 응답에서 간헐 500, 로그에 직렬화 에러.

원인: JPA 엔티티를 그대로 반환해 LAZY 프록시/순환참조가 터짐.

해결: 응답을 DTO/Map으로 변환해서 필요한 필드만 반환(또는 204 No Content).

재발 방지: 컨트롤러 레이어에서 엔티티 직반환 금지 규칙.